### PR TITLE
feat: Add mobile navigation menu

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,10 +5,20 @@ import {
   NavigationMenuLink,
   NavigationMenuList,
 } from "@/components/ui/navigation-menu";
-import { ChevronDownIcon } from "lucide-react";
+import {
+  Sheet,
+  SheetTrigger,
+\  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { ChevronDownIcon, MenuIcon } from "lucide-react";
 
 const navLinkStyle = "inline-flex h-9 w-max items-center justify-center rounded-md bg-transparent px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-transparent transition-colors";
 const navLinkActiveStyle = "inline-flex h-9 w-max items-center justify-center rounded-md bg-transparent px-4 py-2 text-sm font-medium text-foreground hover:bg-transparent transition-colors";
+
+const mobileNavLinkStyle = "flex items-center px-4 py-3 text-base font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors";
+const mobileNavLinkActiveStyle = "flex items-center px-4 py-3 text-base font-medium text-foreground bg-muted rounded-md transition-colors";
 
 type Theme = "light" | "dark" | "system";
 
@@ -18,6 +28,8 @@ const Navbar = () => {
   const [isThemeMenuOpen, setIsThemeMenuOpen] = useState(false);
   const [isProjectsOpen, setIsProjectsOpen] = useState(false);
   const [isProjectsClicked, setIsProjectsClicked] = useState(false);
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isMobileProjectsOpen, setIsMobileProjectsOpen] = useState(false);
   const projectsRef = useRef<HTMLDivElement>(null);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -147,7 +159,134 @@ const Navbar = () => {
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 flex justify-center items-center py-4 bg-background/80 backdrop-blur-md border-b border-border">
-      <NavigationMenu>
+      {/* Mobile Menu Button */}
+      <div className="md:hidden absolute left-4">
+        <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
+          <SheetTrigger asChild>
+            <button
+              className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              aria-label="Open menu"
+            >
+              <MenuIcon className="h-5 w-5" />
+            </button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-[280px] p-0">
+            <SheetHeader className="border-b border-border">
+              <SheetTitle>Menu</SheetTitle>
+            </SheetHeader>
+            <div className="flex flex-col py-4">
+              <a
+                href="/"
+                className={isActive("/") ? mobileNavLinkActiveStyle : mobileNavLinkStyle}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Home
+              </a>
+              <a
+                href="/about"
+                className={isActive("/about") ? mobileNavLinkActiveStyle : mobileNavLinkStyle}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                About
+              </a>
+              
+              {/* Mobile Projects Accordion */}
+              <div>
+                <button
+                  onClick={() => setIsMobileProjectsOpen(!isMobileProjectsOpen)}
+                  className={`w-full flex items-center justify-between px-4 py-3 text-base font-medium transition-colors rounded-md ${isActive("/projects") ? "text-foreground bg-muted" : "text-muted-foreground hover:text-foreground hover:bg-muted"}`}
+                >
+                  Projects
+                  <ChevronDownIcon 
+                    className={`h-4 w-4 transition-transform duration-200 ${isMobileProjectsOpen ? "rotate-180" : ""}`} 
+                  />
+                </button>
+                {isMobileProjectsOpen && (
+                  <div className="pl-4 py-1 space-y-1">
+                    <a
+                      href="/projects"
+                      className="block px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                    >
+                      All Projects
+                    </a>
+                    <a
+                      href="/projects/ctf"
+                      className="block px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                    >
+                      CTF Writeups
+                    </a>
+                    <a
+                      href="/projects/tools"
+                      className="block px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                    >
+                      Security Tools
+                    </a>
+                  </div>
+                )}
+              </div>
+
+              <a
+                href="/blog"
+                className={isActive("/blog") ? mobileNavLinkActiveStyle : mobileNavLinkStyle}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Blog
+              </a>
+              <a
+                href="/certifications"
+                className={isActive("/certifications") ? mobileNavLinkActiveStyle : mobileNavLinkStyle}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Achievements
+              </a>
+              <a
+                href="/contact"
+                className={isActive("/contact") ? mobileNavLinkActiveStyle : mobileNavLinkStyle}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Contact
+              </a>
+
+              {/* Mobile Theme Selector */}
+              <div className="mt-4 px-4 pt-4 border-t border-border">
+                <p className="text-xs text-muted-foreground mb-2 uppercase tracking-wider">Theme</p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => handleThemeChange("light")}
+                    className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors ${theme === "light" ? "border-foreground text-foreground bg-muted" : "border-border text-muted-foreground hover:text-foreground hover:bg-muted"}`}
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleThemeChange("dark")}
+                    className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors ${theme === "dark" ? "border-foreground text-foreground bg-muted" : "border-border text-muted-foreground hover:text-foreground hover:bg-muted"}`}
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                    </svg>
+                  </button>
+                  <button
+                    onClick={() => handleThemeChange("system")}
+                    className={`flex-1 flex items-center justify-center gap-2 px-3 py-2 text-sm rounded-md border transition-colors ${theme === "system" ? "border-foreground text-foreground bg-muted" : "border-border text-muted-foreground hover:text-foreground hover:bg-muted"}`}
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+
+      {/* Desktop Navigation */}
+      <NavigationMenu className="hidden md:flex">
         <NavigationMenuList>
           <NavigationMenuItem>
             <NavigationMenuLink
@@ -293,6 +432,52 @@ const Navbar = () => {
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>
+
+      {/* Mobile Theme Toggle (visible on right side on mobile) */}
+      <div className="md:hidden absolute right-4" data-theme-menu>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            setIsThemeMenuOpen(!isThemeMenuOpen);
+          }}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md bg-transparent text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          aria-label="Toggle theme"
+        >
+          {getThemeIcon()}
+        </button>
+        
+        {isThemeMenuOpen && (
+          <div className="absolute right-0 mt-2 w-36 bg-popover backdrop-blur-md rounded-md border border-border shadow-lg py-1 z-50">
+            <button
+              onClick={() => handleThemeChange("light")}
+              className={`w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-muted transition-colors ${theme === "light" ? "text-foreground" : "text-muted-foreground"}`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+              </svg>
+              Light
+            </button>
+            <button
+              onClick={() => handleThemeChange("dark")}
+              className={`w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-muted transition-colors ${theme === "dark" ? "text-foreground" : "text-muted-foreground"}`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              </svg>
+              Dark
+            </button>
+            <button
+              onClick={() => handleThemeChange("system")}
+              className={`w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-muted transition-colors ${theme === "system" ? "text-foreground" : "text-muted-foreground"}`}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+              System
+            </button>
+          </div>
+        )}
+      </div>
     </nav>
   );
 };


### PR DESCRIPTION
## Summary
This PR adds a responsive mobile navigation menu to improve the user experience on smaller screens.

## Changes
- Add hamburger menu button (visible on mobile only)
- Implement slide-out drawer using shadcn/ui Sheet component
- Add mobile-friendly navigation links with proper styling
- Include accordion-style Projects submenu for mobile
- Add mobile theme selector with light/dark/system options
- Desktop navigation is hidden on mobile, replaced with the new mobile menu

## Testing
- Tested on various screen sizes
- Theme switching works correctly on mobile
- All navigation links function properly
- Projects accordion expands/collapses as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced mobile-optimized navigation menu with slide-in design for improved mobile browsing experience
  * Added expandable Projects accordion on mobile displaying subcategories
  * Implemented mobile theme switcher for quick Light/Dark/System preference changes
  * Enhanced navigation with dedicated mobile menu items for all main sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->